### PR TITLE
Add missing ts-loader compile option

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ then transpile your code with `ttsc`.
 const TsMacros = require("ts-macros").default;
 
 options: {
+      compiler: "ttypescript",
       getCustomTransformers: program => {
         before: [TsMacros(program)]
       }


### PR DESCRIPTION
As I was setting this up with Webpack, I couldn't figure out why the macros weren't working when using the README example. I went to TTypeScript's repository and saw that the compiler option needs to be set.