### PR TITLE
Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ By default, typescript doesn't allow you to add custom transformers, so you must
 npm i --save-dev ttypescript
 ```
 
-and add the `ts-docs` transformer to your `tsconfig.json`:
+and add the `ts-macros` transformer to your `tsconfig.json`:
 
 ```json
 "compilerOptions": {


### PR DESCRIPTION
Shouldn't it be `ts-macros` instead of `ts-docs`?