### PR TITLE
Improve $$typeToString

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To read more about ts-macros features, visit the [documentation](https://googlef
 - Create abstractions without the runtime cost
 
 **What you can't do with ts-macros**:
-- Generate types which you can use in your code. ts-docs is only a transformer, it's ran **after** typechecking, so generating different types has no effect. However, the code inside the macro itself still gets typechecked
+- Generate types which you can use in your code. ts-macros is only a transformer, it's ran **after** typechecking, so generating different types has no effect. However, the code inside the macro itself still gets typechecked
 
 ## Install
 

--- a/tests/integrated/builtins/typeToString.test.ts
+++ b/tests/integrated/builtins/typeToString.test.ts
@@ -16,4 +16,20 @@ describe("$$typeToString", () => {
         expect($test!<boolean>(true)).to.be.equal(true);
     });
 
+    type Foo = {
+        foo: boolean
+        bar: Bar
+    }
+
+    type Bar = number
+
+    function $test2<K extends keyof Foo>(key: K) {
+        return $$typeToString!<Foo[K]>()
+    }
+
+    it("Should stringify complex type", () => {
+        expect($test2!("foo")).to.equal('boolean');
+        expect($test2!("bar")).to.equal('Bar');
+    });
+
 });


### PR DESCRIPTION
I would like to do something like this in my code:

```ts
type Foo = {
    foo: boolean
    bar: Bar
}

type Bar = number

function $test2<K extends keyof Foo>(key: K) {
    return $$typeToString!<Foo[K]>()
}

it("Should stringify complex type", () => {
    expect($test2!("foo")).to.equal('boolean');
    expect($test2!("bar")).to.equal('Bar')
})
```

but it fails.

I get: 

```diff
Should stringify complex type:

  AssertionError: expected 'Foo[K]' to equal 'boolean'
  + expected - actual

-Foo[K]
+boolean
```

and:

```diff
  AssertionError: expected 'Foo[K]' to equal 'Bar'
  + expected - actual

-Foo[K]
+Bar
```

Would it be possible to make this work?

I've tried to play around in the code and do this myself, but I don't understand `ts.Type` very well, and I don't know which of its attributes would be relevant for what I want to do.

Any help would be appreciated :) 