### PR TITLE
fix some "labeled" bugs

### DIFF
--- a/tests/integrated/labels/nomacro.test.ts
+++ b/tests/integrated/labels/nomacro.test.ts
@@ -1,0 +1,50 @@
+import { expect } from "chai";
+const { $$ts } = require("../../../../dist/index");
+
+function $noop(_: any): void {
+}
+function $noop1(_: any): void {
+}
+function $noop2(_: any): void {
+}
+
+describe("None macro js labels", () => {
+
+    it("none macro label not excluded from source", () => {
+        let value = "some";
+        patch: {
+            value = "ot";
+            break patch;
+        }
+        $patch: {
+            value += "her";
+            break $patch;
+        }
+        expect(value).to.be.equal("other");
+    });
+
+    it("macro labels processed in none macro labeled blocks", () => {
+        let value = "some";
+        patch: {
+            value = ($$ts!('() => "other"'))();
+            break patch;
+        }
+        expect(value).to.be.equal("other");
+    });
+
+    it("process macros in macro labeled expression", () => {
+        let value = "some";
+        $noop: value = ($$ts!('() => "other"'))();
+        expect(value).to.be.equal("other");
+    });
+
+    it("process macros in deep macro labeled expression", () => {
+        let value = "some";
+        $noop: 
+        $noop1: 
+        $noop2: 
+        value = ($$ts!('() => "other"'))();
+        expect(value).to.be.equal("other");
+    });
+
+});

--- a/tests/snapshots/artifacts/labels_nomacro.test.js
+++ b/tests/snapshots/artifacts/labels_nomacro.test.js
@@ -1,0 +1,36 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const chai_1 = require("chai");
+const { $$ts } = require("../../../../dist/index");
+describe("None macro js labels", () => {
+    it("none macro label not excluded from source", () => {
+        let value = "some";
+        patch: {
+            value = "ot";
+            break patch;
+        }
+        $patch: {
+            value += "her";
+            break $patch;
+        }
+        (0, chai_1.expect)(value).to.be.equal("other");
+    });
+    it("macro labels processed in none macro labeled blocks", () => {
+        let value = "some";
+        patch: {
+            value = (() => "other")();
+            break patch;
+        }
+        (0, chai_1.expect)(value).to.be.equal("other");
+    });
+    it("process macros in macro labeled expression", () => {
+        let value = "some";
+        $noop: value = (() => "other")();
+        (0, chai_1.expect)(value).to.be.equal("other");
+    });
+    it("process macros in deep macro labeled expression", () => {
+        let value = "some";
+        $noop: $noop1: $noop2: value = (() => "other")();
+        (0, chai_1.expect)(value).to.be.equal("other");
+    });
+});


### PR DESCRIPTION
Ast traversing is buggy. 
I fix some errors and mark with "todo" some suspicious places for which I didn't come up with test cases.

All places with `return node;` and `return;` require checks.

I think it would be a good idea to rewrite the tree traversal so that there is only one `return` for the function. This would help to avoid errors related to forgetting to traversing child nodes.