### PR TITLE
Improve $$err typing (and fix doc)

### DIFF
--- a/playground/utils/transpile.ts
+++ b/playground/utils/transpile.ts
@@ -14,7 +14,7 @@ declare function $$define(varname: string, initializer: unknown, let?: boolean, 
 declare function $$i() : number;
 declare function $$length(arr: Array<any>|string) : number;
 declare function $$ident(str: string) : any;
-declare function $$err(str: string) : void;
+declare function $$err(str: string) : never;
 declare function $$includes<T>(arr: Array<T>, val: T) : boolean;
 declare function $$includes(arr: string, val: string) : boolean;
 declare function $$slice<T>(str: Array<T>, start?: number, end?: number) : Array<T>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -213,7 +213,7 @@ export declare function $$ident(str: string) : any;
  * @param str - The error to throw.
  * @category Built-in Macros
  */
-export declare function $$err(str: string) : void;
+export declare function $$err(str: string) : never;
 
 /**
  * Checks if `val` is included in the array literal / string.

--- a/src/index.ts
+++ b/src/index.ts
@@ -472,7 +472,7 @@ export interface RawContext {
 export declare function $$raw<T>(fn: (ctx: RawContext, ...args: any[]) => ts.Node | ts.Node[] | undefined) : T;
 
 /**
- * Expands to a string literal of the expression. If the transformation is not possible, it expands to `undefined`.
+ * Expands to a string literal of the expression. If the transformation is not possible, it expands to `null`.
  * 
  * Expressions that can be transformed:
  * 

--- a/src/index.ts
+++ b/src/index.ts
@@ -472,7 +472,7 @@ export interface RawContext {
 export declare function $$raw<T>(fn: (ctx: RawContext, ...args: any[]) => ts.Node | ts.Node[] | undefined) : T;
 
 /**
- * Expands to a string literal of the expression. If the transformation is not possible, it expands to `null`.
+ * Expands to a string literal of the expression. If the transformation is not possible, it expands to `"null"`.
  * 
  * Expressions that can be transformed:
  * 


### PR DESCRIPTION
- If the transformation is not possible, `$$text` expands to `"null"`, not `undefined`. Corrected doc accordingly.
---
- I should be able to write this:
```ts
function $$textSafe(exp: unknown): string {
  const $res = $$text!(exp)

  if ($res === 'null') {
    return $$err!('$$text: exp in not transformable.')
  }

  return $res
}
```
But I get an error:
![image](https://github.com/GoogleFeud/ts-macros/assets/18679417/9bd53d0e-24e4-4b18-ab15-b7a7dfcfa759)
Updating, `$$err` return type to `never` fixes the problem.